### PR TITLE
Add Atom feed to website

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -53,7 +53,10 @@
 
         <footer>
         {% if site.github.is_project_page %}
-          <a href="{{site.baseurl}}/"><h3 style="text-align: center;"">Home</h3></a><br>
+          <div style="text-align: center;">
+            <a href="{{site.baseurl}}/"><h3 style="display: inline-block; padding-right: 2%">Home</h3></a>
+            <a href="{{site.baseurl}}/feed.xml" type="application/atom+xml"><h3 style="display: inline-block;">Feed</h3></a>
+          </div><br>
           {{ site.title | default: site.github.repository_name }} is maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a><br>
         {% endif %}
         </footer>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/8166212/151096574-a6fb5873-218e-45b5-ae5d-099ca32864f7.png)

This adds a Feed button next to the Home button. The `type="application/atom+xml"` helps certain RSS readers extract the feed from the homepage.